### PR TITLE
Fix column mapping bug and expand unit tests

### DIFF
--- a/backend/data_fetcher_facade.py
+++ b/backend/data_fetcher_facade.py
@@ -276,8 +276,10 @@ class DataFetcherFacade:
         result = data.copy()
         
         # 应用列名映射
-        reverse_mapping = {v: k for k, v in self._column_mapping.items()}
-        result = result.rename(columns=reverse_mapping)
+        # _column_mapping 保存的是新接口列名到旧接口列名的映射
+        # 在标准化输出时需要将新列名转换为旧列名，
+        # 因此直接使用该映射而不是反向映射
+        result = result.rename(columns=self._column_mapping)
         
         # 确保必要列存在
         required_columns = ['open', 'high', 'low', 'close', 'volume']

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,7 +62,7 @@ python -m tests.run_tests
 
 | 测试名称 | 目的 | 关键验证点 |
 |---------|------|-----------|
-| `akshare_fetch_ok` | Akshare数据获取 | API调用、数据格式 |
+| `akshare_fetch_ok` | AkShare数据获取 | API调用、数据格式 |
 | `tushare_fetch_ok` | Tushare数据获取 | 配额管理、数据质量 |
 | `merge_fallback_ok` | 数据源合并回退 | 优先级处理、数据完整性 |
 | `zipline_ingest_ok` | Zipline数据摄入 | 格式转换、数据验证 |
@@ -521,7 +521,7 @@ unit_tests.py - 单元测试模块
 
 integration_tests.py - 集成测试模块
 
-✅ akshare_fetch_ok - Akshare数据获取测试
+✅ akshare_fetch_ok - AkShare数据获取测试
 ✅ tushare_fetch_ok - Tushare数据获取测试
 ✅ merge_fallback_ok - 数据源合并回退测试
 ✅ zipline_ingest_ok - Zipline数据摄入测试

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -245,7 +245,31 @@ class UnitTests:
         assert cache.get("test_basic") is None, "清理后应该无法获取数据"
         
         print("✓ 数据缓存命中测试通过")
-    
+
+    def facade_output_format_ok(self):
+        """测试数据获取门面的列名标准化"""
+        # 导入在函数内部以避免不必要的依赖
+        from backend.data_fetcher_facade import DataFetcherFacade
+
+        facade = DataFetcherFacade(enable_new_fetcher=False, fallback_to_csv=False)
+
+        raw = pd.DataFrame({
+            'datetime': [datetime(2024, 1, 1)],
+            'open': [1.1],
+            'high': [1.2],
+            'low': [1.0],
+            'adj_close': [1.1],
+            'volume': [100]
+        })
+
+        formatted = facade._normalize_output_format(raw)
+
+        assert 'date' in formatted.columns, "datetime 应映射为 date"
+        assert 'close' in formatted.columns, "adj_close 应映射为 close"
+        assert formatted.loc[0, 'close'] == raw.loc[0, 'adj_close'], "close 值应来源于 adj_close"
+
+        print("✓ 门面列名标准化测试通过")
+
     def run_all_unit_tests(self):
         """运行所有单元测试"""
         print("运行单元测试...")
@@ -254,7 +278,8 @@ class UnitTests:
             self.normalize_sessions_ok,
             self.adjust_pre_ok,
             self.symbol_map_ok,
-            self.cache_hit_ok
+            self.cache_hit_ok,
+            self.facade_output_format_ok
         ]
         
         for test in tests:


### PR DESCRIPTION
## Summary
- Correct column renaming in `DataFetcherFacade` to ensure new data columns map to legacy names
- Standardize documentation to use proper "AkShare" spelling
- Add unit test validating `DataFetcherFacade` output format and include it in test suite

## Testing
- `python tests/unit_tests.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68b5681f490483229b2512d5da358287